### PR TITLE
Update streamer card

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
+    "axios": "^0.16.1",
     "mobx": "^3.1.9",
     "mobx-react": "^4.1.7",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-http-request": "^1.0.3",
     "react-toolbox": "^2.0.0-beta.8",
     "react-toolbox-themr": "^1.0.2",
     "styled-components": "^1.4.4"

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import styled from 'styled-components';
-import { Card, CardTitle, CardActions, CardText } from 'react-toolbox/lib/card';
-import Button from 'react-toolbox/lib/button/Button';
-import Request from 'react-http-request';
+import StreamerCard from './StreamerCard';
 
 const Side = styled.div`
   float:left;
@@ -15,28 +13,6 @@ const Side = styled.div`
   color: #ecf0f1;
   overflow-y: auto;
 `;
-
-const StyledCard = styled(Card)`
-  background: #555555;
-  color: #ecf0f1;
-  margin: 10px;
-  width: calc(100% - 20px);
-  flex: 0 0 auto;
-`;
-
-const StreamerCard = ({ streamer, callback, picture, status }) => (
-  <StyledCard raised>
-    {picture
-      ? <CardTitle title={streamer} avatar={picture} />
-      : <CardTitle title={streamer} />}
-    <CardText>
-      {status}
-    </CardText>
-    <CardActions>
-      <Button raised label="Watch" value={streamer} onClick={callback} />
-    </CardActions>
-  </StyledCard>
-);
 
 @observer class Sidebar extends Component {
   constructor() {
@@ -53,36 +29,7 @@ const StreamerCard = ({ streamer, callback, picture, status }) => (
       <Side>
         <h2>Favorites</h2>
         {this.props.store.favorites.map(item => (
-          <Request
-            url={`https://api.twitch.tv/kraken/channels/${item}`}
-            method="get"
-            accept="application/json"
-            headers={{ 'Client-ID': 'gc6rul66vivvwv6qwj98v529l9mpyo' }}
-            verbose={false}
-          >
-            {({ error, result, loading }) => {
-              if (loading) {
-                return (
-                  <StreamerCard
-                    key={item}
-                    streamer={item}
-                    callback={this.handleFavoriteClick}
-                    status="Loading..."
-                  />
-                );
-              } else {
-                return (
-                  <StreamerCard
-                    key={item}
-                    streamer={item}
-                    callback={this.handleFavoriteClick}
-                    picture={result.body.logo}
-                    status={result.body.status}
-                  />
-                );
-              }
-            }}
-          </Request>
+          <StreamerCard key={item} streamer={item} store={this.props.store} />
         ))}
       </Side>
     );

--- a/src/components/StreamerCard.js
+++ b/src/components/StreamerCard.js
@@ -13,7 +13,7 @@ const StyledCard = styled(Card)`
   flex: 0 0 auto;
 `;
 
-const MaterialCard = ({ streamer, callback, picture, status }) => (
+const MaterialCard = ({ streamer, onClick, picture, status, onRemove }) => (
   <StyledCard raised>
     {picture
       ? <CardTitle title={streamer} avatar={picture} />
@@ -21,11 +21,23 @@ const MaterialCard = ({ streamer, callback, picture, status }) => (
     <CardText>
       {status}
     </CardText>
-    {callback
-      ? <CardActions>
-          <Button raised label="Watch" value={streamer} onClick={callback} />
-        </CardActions>
-      : null}
+    <CardActions>
+      {onClick
+        ? <Button
+            raised
+            primary
+            label="Watch"
+            value={streamer}
+            onClick={onClick}
+          />
+        : null}
+      <Button
+        raised
+        label="Remove"
+        value={streamer}
+        onClick={onRemove}
+      />
+    </CardActions>
   </StyledCard>
 );
 
@@ -41,10 +53,15 @@ const MaterialCard = ({ streamer, callback, picture, status }) => (
     };
 
     this.handleFavoriteClick = this.handleFavoriteClick.bind(this);
+    this.handleRemoveClick = this.handleRemoveClick.bind(this);
   }
 
   handleFavoriteClick(e) {
     this.props.store.setChannel(e.target.value);
+  }
+
+  handleRemoveClick(e) {
+    this.props.store.removeFavorite(e.target.value);
   }
 
   componentDidMount() {
@@ -108,7 +125,13 @@ const MaterialCard = ({ streamer, callback, picture, status }) => (
     }
 
     if (this.state.loading) {
-      return <MaterialCard streamer={streamer} status="Loading..." />;
+      return (
+        <MaterialCard
+          streamer={streamer}
+          status="Loading..."
+          onRemove={this.handleRemoveClick}
+        />
+      );
     }
 
     const isOnline = this.state.streamsData.stream !== null;
@@ -116,9 +139,10 @@ const MaterialCard = ({ streamer, callback, picture, status }) => (
     return (
       <MaterialCard
         streamer={streamer}
-        callback={isOnline ? this.handleFavoriteClick : null}
         picture={this.state.channelsData.logo}
         status={this.state.channelsData.status}
+        onClick={isOnline ? this.handleFavoriteClick : null}
+        onRemove={this.handleRemoveClick}
       />
     );
   }

--- a/src/components/StreamerCard.js
+++ b/src/components/StreamerCard.js
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import styled from 'styled-components';
+import { Card, CardTitle, CardActions, CardText } from 'react-toolbox/lib/card';
+import Button from 'react-toolbox/lib/button/Button';
+import axios from 'axios';
+
+const StyledCard = styled(Card)`
+  background: #555555;
+  color: #ecf0f1;
+  margin: 10px;
+  width: calc(100% - 20px);
+  flex: 0 0 auto;
+`;
+
+const MaterialCard = ({ streamer, callback, picture, status }) => (
+  <StyledCard raised>
+    {picture
+      ? <CardTitle title={streamer} avatar={picture} />
+      : <CardTitle title={streamer} />}
+    <CardText>
+      {status}
+    </CardText>
+    {callback
+      ? <CardActions>
+          <Button raised label="Watch" value={streamer} onClick={callback} />
+        </CardActions>
+      : null}
+  </StyledCard>
+);
+
+@observer class StreamerCard extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      streamsData: null,
+      channelData: null,
+      loading: true,
+      error: null
+    };
+
+    this.handleFavoriteClick = this.handleFavoriteClick.bind(this);
+  }
+
+  handleFavoriteClick(e) {
+    this.props.store.setChannel(e.target.value);
+  }
+
+  componentDidMount() {
+    const { streamer } = this.props;
+    const config = {
+      headers: {
+        'Client-ID': 'gc6rul66vivvwv6qwj98v529l9mpyo'
+      }
+    };
+
+    axios
+      .get(`https://api.twitch.tv/kraken/channels/${streamer}`, config)
+      .then(res => {
+        this.setState({
+          channelsData: res.data
+        });
+
+        if (this.state.streamsData) {
+          this.setState({
+            loading: false
+          });
+        }
+      })
+      .catch(error => {
+        console.log(error);
+        this.setState({
+          error: JSON.stringify(error)
+        });
+      });
+
+    axios
+      .get(`https://api.twitch.tv/kraken/streams/${streamer}`, config)
+      .then(res => {
+        this.setState({
+          streamsData: res.data
+        });
+
+        if (this.state.channelsData) {
+          this.setState({
+            loading: false
+          });
+        }
+      })
+      .catch(error => {
+        console.log(error);
+        this.setState({
+          error: JSON.stringify(error)
+        });
+      });
+  }
+
+  render() {
+    const { streamer } = this.props;
+
+    if (this.state.error) {
+      return (
+        <div>
+          <h3>Error: {this.state.error}</h3>
+        </div>
+      );
+    }
+
+    if (this.state.loading) {
+      return <MaterialCard streamer={streamer} status="Loading..." />;
+    }
+
+    const isOnline = this.state.streamsData.stream !== null;
+
+    return (
+      <MaterialCard
+        streamer={streamer}
+        callback={isOnline ? this.handleFavoriteClick : null}
+        picture={this.state.channelsData.logo}
+        status={this.state.channelsData.status}
+      />
+    );
+  }
+}
+
+export default StreamerCard;

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,7 +208,7 @@ async@1.x, async@^1.3.0, async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^0.9.0, async@~0.9.0:
+async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
@@ -244,6 +244,12 @@ aws-sign2@~0.6.0:
 aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+axios@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.1.tgz#c0b6d26600842384b8f509e57111f0d2df8223ca"
+  dependencies:
+    follow-redirects "^1.2.3"
 
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -1292,12 +1298,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@~0.0.4:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f"
-  dependencies:
-    delayed-stream "0.0.5"
-
 commander@2.9.x, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
@@ -1313,10 +1313,6 @@ commander@~2.8.1:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-
-component-emitter@~1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 compressible@~2.0.8:
   version "2.0.10"
@@ -1400,10 +1396,6 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-
-cookiejar@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.0.6.tgz#0abf356ad00d1c5a219d88d44518046dd026acfe"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1626,12 +1618,6 @@ debug@0.7.4, debug@~0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
-debug@2, debug@2.6.3, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
-  dependencies:
-    ms "0.7.2"
-
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -1641,6 +1627,12 @@ debug@2.2.0, debug@~2.2.0:
 debug@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
+
+debug@2.6.3, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.5:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
@@ -1677,10 +1669,6 @@ del@^2.0.2:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
-
-delayed-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2157,7 +2145,7 @@ express@^4.13.3:
     utils-merge "1.0.0"
     vary "~1.1.0"
 
-extend@3.0.0, extend@~3.0.0:
+extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -2317,6 +2305,12 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
+follow-redirects@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.2.3.tgz#01abaeca85e3609837d9fcda3167a7e42fdaca21"
+  dependencies:
+    debug "^2.4.5"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2340,14 +2334,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.2.0.tgz#26f8bc26da6440e299cbdcfb69035c4f77a6e466"
-  dependencies:
-    async "~0.9.0"
-    combined-stream "~0.0.4"
-    mime-types "~2.0.3"
-
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -2355,10 +2341,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formidable@~1.0.14:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -3660,7 +3642,7 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-methods@~1.1.1, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -3686,21 +3668,11 @@ micromatch@^2.1.5, micromatch@^2.3.11:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-db@~1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.12.0.tgz#3d0c63180f458eb10d325aaa37d7c58ae312e9d7"
-
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
-
-mime-types@~2.0.3:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6"
-  dependencies:
-    mime-db "~1.12.0"
 
 mime@1.2.x:
   version "1.2.11"
@@ -4839,10 +4811,6 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
-
 qs@6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -4935,12 +4903,6 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "~15.5.0"
 
-react-http-request@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-http-request/-/react-http-request-1.0.3.tgz#e071bf0d3e815b6448f298218569c2bf48ef0080"
-  dependencies:
-    superagent "1.7.2"
-
 react-style-proptype@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-2.0.2.tgz#b4687990ac256deed89ee5777a3c58de5ac7bd15"
@@ -5005,15 +4967,6 @@ read-pkg@^1.0.0:
 readable-stream@1.0:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@1.0.27-1:
-  version "1.0.27-1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.27-1.tgz#6b67983c20357cefd07f0165001a16d710d91078"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -5087,10 +5040,6 @@ redeyed@~1.0.0:
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
     esprima "~3.0.0"
-
-reduce-component@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
 
 reduce-css-calc@^1.2.6, reduce-css-calc@^1.2.7:
   version "1.3.0"
@@ -5639,22 +5588,6 @@ sumchecker@^1.2.0:
   dependencies:
     debug "^2.2.0"
     es6-promise "^4.0.5"
-
-superagent@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-1.7.2.tgz#65f9eed4f5361320c9d874412ab77bebaea4b572"
-  dependencies:
-    component-emitter "~1.2.0"
-    cookiejar "2.0.6"
-    debug "2"
-    extend "3.0.0"
-    form-data "0.2.0"
-    formidable "~1.0.14"
-    methods "~1.1.1"
-    mime "1.3.4"
-    qs "2.3.3"
-    readable-stream "1.0.27-1"
-    reduce-component "1.0.1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR remodels streamer cards and  adds a few improvements, namely:

- [x] Only show streamer Watch button when streamer is online
- [x] Add ability to remove streamer from the card
- [x] Restructure card for multiple Ajax requests
  - For now this allows us to see info on channel and streams via 2 api endpoints at once. This may allow us to fetch more information about the channel in the future more easily.